### PR TITLE
Fix Travis CI and Windows builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,17 @@
 sudo: false
 language: node_js
 node_js:
-  - 'iojs'
+  - 'stable'
+  - '5'
+  - '4'
   - '0.12'
   - '0.10'
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8
+      - libstdc++-4.8-dev
+before_install:
+  - export CXX="g++-4.8" CC="gcc-4.8"

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 var fs = require('fs');
-var isXz = require('is-xz');
 var lzmaNative = require('lzma-native');
 var objectAssign = require('object-assign');
 var stripDirs = require('strip-dirs');
@@ -27,7 +26,7 @@ module.exports = function (opts) {
 			return;
 		}
 
-		if (!file.extract || !isXz(file.contents)) {
+		if (!file.extract || !lzmaNative.isXZ(file.contents)) {
 			cb(null, file);
 			return;
 		}

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function (opts) {
 
 	return through.obj(function (file, enc, cb) {
 		var extract = tarStream.extract();
-		var xz = lzmaNative.createStream('autoDecoder');
+		var xz = lzmaNative.createDecompressor();
 		var self = this;
 
 		if (file.isNull()) {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "xz"
   ],
   "dependencies": {
-    "is-xz": "^1.0.0",
     "lzma-native": "^1.0.2",
     "object-assign": "^2.0.0",
     "strip-dirs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "is-xz": "^1.0.0",
-    "lzma-native": "^0.2.11",
+    "lzma-native": "^1.0.2",
     "object-assign": "^2.0.0",
     "strip-dirs": "^1.0.0",
     "tar-stream": "^1.1.1",


### PR DESCRIPTION
Use GCC 4.8 for Travis builds so that `-std=c++11` is accepted as a command line option.
