### PR TITLE
Update lzma-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "decompress-tar": "^4.1.0",
     "file-type": "^3.8.0",
     "is-stream": "^1.1.0",
-    "lzma-native": "^1.0.2"
+    "lzma-native": "^3.0.1"
   },
   "devDependencies": {
     "ava": "*",


### PR DESCRIPTION
lzma-native 1.0.2 is deprecated and they does not ship pre-build version for node 7 and 8

Those are all the prebuilt versions available:
https://node-pre-gyp.entless.org/lzma-native/